### PR TITLE
feat: add deterministic sim + smoke script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "ts-node --esm src/ingest.ts",
-    "start": "node dist/ingest.js",
-    "build": "tsc -p .",
-    "test": "jest --runInBand"
+  "dev": "ts-node --esm src/ingest.ts",
+  "start": "node dist/ingest.js",
+  "build": "tsc -p .",
+  "test": "jest --runInBand",
+  "smoke": "tsc && node dist/ingest.js"
   },
   "dependencies": {
   "sqlite3": "^5.1.6",

--- a/backend/scripts/run-smoke.ps1
+++ b/backend/scripts/run-smoke.ps1
@@ -1,0 +1,98 @@
+<#
+run-smoke.ps1
+Automated smoke script for backend (development only).
+
+What it does:
+ - builds the backend (tsc)
+ - starts the backend server in background (node dist/ingest.js)
+ - waits for server to be listening on configured PORT (default 3001)
+ - posts a sample CSV to /api/ingest
+ - polls job status until 'completed' or 'failed'
+ - stops the server process
+
+Usage (PowerShell):
+  Set-Location -Path "d:\FDD\backend"
+  ./scripts/run-smoke.ps1 -SamplePath "..\public\samples\sample_financial_data.csv" -ForceSimulate
+
+Parameters:
+ -SamplePath: path to a sample file to upload (relative to backend folder)
+ -ForceSimulate: switch to set FORCE_SIMULATE_GEMINI_TRANSIENTS=true for deterministic transient
+ -UseMock: switch to set USE_ML_CLIENT_MOCK=true to avoid calling external ML service
+#>
+param(
+  [string]$SamplePath = "..\public\samples\sample_financial_data.csv",
+  [int]$Port = 3001,
+  [int]$PollIntervalSec = 1,
+  [int]$TimeoutSec = 120,
+  [switch]$ForceSimulate,
+  [switch]$UseMock
+)
+
+# Build
+Write-Host "Building backend..."
+npm run build
+if ($LASTEXITCODE -ne 0) { throw "Build failed" }
+
+# Start server
+$env:PORT = $Port
+if ($ForceSimulate) { $env:FORCE_SIMULATE_GEMINI_TRANSIENTS = 'true' }
+if ($UseMock) { $env:USE_ML_CLIENT_MOCK = 'true' }
+$env:LLM_PROVIDER = $env:LLM_PROVIDER -or 'gemini'
+$env:GEMINI_API_KEY = $env:GEMINI_API_KEY -or 'test-key'
+
+Write-Host "Starting backend server (background)..."
+$startInfo = @{ FilePath = 'node'; ArgumentList = 'dist/ingest.js'; RedirectStandardOutput = $true; RedirectStandardError = $true }
+$proc = Start-Process @startInfo -PassThru
+Start-Sleep -Milliseconds 500
+
+# Wait for server to be up
+$end = (Get-Date).AddSeconds($TimeoutSec)
+$up = $false
+while ((Get-Date) -lt $end) {
+  try {
+    $r = Test-NetConnection -ComputerName 'localhost' -Port $Port -WarningAction SilentlyContinue
+    if ($r.TcpTestSucceeded) { $up = $true; break }
+  } catch { }
+  Start-Sleep -Seconds 1
+}
+if (-not $up) {
+  Write-Host "Server failed to start within timeout. Killing process..."
+  Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+  throw "Server did not start"
+}
+Write-Host "Server listening on http://localhost:$Port"
+
+# Post sample file
+$fullPath = Join-Path -Path (Resolve-Path ..\) -ChildPath $SamplePath
+if (-not (Test-Path $SamplePath)) {
+  Write-Host "Sample file not found at $SamplePath"; Stop-Process -Id $proc.Id -Force; throw "Sample not found" }
+Write-Host "Posting sample file: $SamplePath"
+try {
+  $form = @{ files = Get-Item $SamplePath }
+  $resp = Invoke-RestMethod -Uri "http://localhost:$Port/api/ingest" -Method Post -Form $form -ErrorAction Stop
+} catch {
+  Write-Host "Upload failed: $_"; Stop-Process -Id $proc.Id -Force; throw $_
+}
+if (-not $resp.jobId) { Write-Host "No jobId in response: $($resp|ConvertTo-Json -Depth 2)"; Stop-Process -Id $proc.Id -Force; throw "No jobId" }
+$jobId = $resp.jobId
+Write-Host "Created job: $jobId"
+
+# Poll job
+$deadline = (Get-Date).AddSeconds($TimeoutSec)
+while ((Get-Date) -lt $deadline) {
+  Start-Sleep -Seconds $PollIntervalSec
+  try {
+    $j = Invoke-RestMethod -Uri "http://localhost:$Port/api/jobs/$jobId" -Method Get -ErrorAction Stop
+  } catch {
+    Write-Host "Failed to query job status: $_"; continue
+  }
+  Write-Host "Job status: $($j.status) progress=$($j.progress)"
+  if ($j.status -eq 'completed' -or $j.status -eq 'failed') { break }
+}
+
+# Stop server
+Write-Host "Stopping server (pid=$($proc.Id))"
+Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+
+Write-Host "Final job state:"; $j | ConvertTo-Json -Depth 5
+if ($j.status -eq 'completed') { Write-Host "Smoke test succeeded"; exit 0 } else { Write-Host "Smoke test failed"; exit 2 }

--- a/backend/src/mlClient.ts
+++ b/backend/src/mlClient.ts
@@ -252,24 +252,38 @@ async function callGeminiAPI(jobId: string, docText: string, topK: number): Prom
   } catch (e) {
     // ignore
   }
-  // Optional transient simulation for local dev/testing. When enabled this
-  // will randomly throw a simulated 503 once per process so we can validate
-  // retry/fallback behavior in live containers. Only active when
-  // SIMULATE_GEMINI_TRANSIENTS=true and NODE_ENV !== 'production'.
+  // Optional transient simulation for local dev/testing. Two modes supported:
+  // 1) SIMULATE_GEMINI_TRANSIENTS=true -> randomly simulate a single transient 503 once per process
+  // 2) FORCE_SIMULATE_GEMINI_TRANSIENTS=true -> deterministically simulate a single transient 503 once per jobId
+  // Both modes are only active when NODE_ENV !== 'production'. Keep behavior limited so retries can exercise fallback logic.
   try {
-    if ((process.env.SIMULATE_GEMINI_TRANSIENTS || '').toLowerCase() === 'true' && (process.env.NODE_ENV || '').toLowerCase() !== 'production') {
-      // simulate at most once per process to avoid flapping
-      if (!(global as any).__simulated_gemini_transient__) {
-        // 50% chance to simulate — random but deterministic enough for testing
-        if (Math.random() < 0.5) {
-          (global as any).__simulated_gemini_transient__ = true;
-          console.warn('Simulated transient 503 (SIMULATE_GEMINI_TRANSIENTS=true)');
-          const se: any = new Error('Simulated transient 503');
-          se.response = { status: 503, data: 'Simulated transient 503' };
+    const nodeEnv = (process.env.NODE_ENV || '').toLowerCase();
+    // Module-scoped marker for job-level deterministic simulation
+    (global as any).__force_simulated_gemini_jobs__ = (global as any).__force_simulated_gemini_jobs__ || new Set<string>();
+    if (nodeEnv !== 'production') {
+      if ((process.env.FORCE_SIMULATE_GEMINI_TRANSIENTS || '').toLowerCase() === 'true') {
+        const seen: Set<string> = (global as any).__force_simulated_gemini_jobs__;
+        if (!seen.has(jobId)) {
+          seen.add(jobId);
+          console.warn(`Deterministic simulated transient 503 for job ${jobId} (FORCE_SIMULATE_GEMINI_TRANSIENTS=true)`);
+          const se: any = new Error('Simulated transient 503 (forced)');
+          se.response = { status: 503, data: 'Simulated transient 503 (forced)' };
           throw se;
         }
-        // mark even when we decide not to simulate so subsequent calls won't simulate again
-        (global as any).__simulated_gemini_transient__ = true;
+      } else if ((process.env.SIMULATE_GEMINI_TRANSIENTS || '').toLowerCase() === 'true') {
+        // simulate at most once per process to avoid flapping
+        if (!(global as any).__simulated_gemini_transient__) {
+          // 50% chance to simulate
+          if (Math.random() < 0.5) {
+            (global as any).__simulated_gemini_transient__ = true;
+            console.warn('Simulated transient 503 (SIMULATE_GEMINI_TRANSIENTS=true)');
+            const se: any = new Error('Simulated transient 503');
+            se.response = { status: 503, data: 'Simulated transient 503' };
+            throw se;
+          }
+          // mark even when we decide not to simulate so subsequent calls won't simulate again
+          (global as any).__simulated_gemini_transient__ = true;
+        }
       }
     }
     const resp = await axios.post(url, geminiPayload, { headers, timeout: 60000 });


### PR DESCRIPTION
Adds deterministic simulation for Genesis/Gemini transient errors and an automated backend smoke script.

Checklist:
- [x] FORCE_SIMULATE_GEMINI_TRANSIENTS implemented (per-job deterministic transient then mocked success)
- [x] SIMULATE_GEMINI_TRANSIENTS retained (random dev simulation)
- [x] npm smoke script added to backend/package.json
- [x] Automated smoke script added: `backend/scripts/run-smoke.ps1`

How to run smoke locally:
1) Build and run the server with deterministic simulate and mock ML assemble:
```powershell
Set-Location -Path 'D:\FDD\backend'
$env:FORCE_SIMULATE_GEMINI_TRANSIENTS='true'
$env:USE_ML_CLIENT_MOCK='true'
$env:LLM_PROVIDER='gemini'
$env:GEMINI_API_KEY='test-key'
npm run smoke
# In another shell:
curl -F "files=@..\\public\\samples\\sample_financial_data.csv" http://localhost:3001/api/ingest
```

Notes:
- This PR is intended for dev testing only. Do not enable `FORCE_SIMULATE_GEMINI_TRANSIENTS` in production environments.
- After merging, rotate any test credentials that were previously committed or used during validation.
